### PR TITLE
Add ‘ily’ file type for include LilyPond files

### DIFF
--- a/grammars/lilypond.cson
+++ b/grammars/lilypond.cson
@@ -1,4 +1,5 @@
 'fileTypes': [
+  'ily',
   'ly'
 ]
 'name': 'LilyPond'


### PR DESCRIPTION
I always use file type ‘ily’ to have difference between lilypond file and include lilypond file.
I suggest add this file type to your package.
Papilip

PS: you have a a dependence: "language-lisp", but `npm install language-lisp` don’t return anything. 
