### PR TITLE
Change scope-name to `scope.lilypond`

### DIFF
--- a/grammars/lilypond.cson
+++ b/grammars/lilypond.cson
@@ -32,4 +32,4 @@
     'include': 'source.lilypond-schememode'
   }
 ]
-'scopeName': 'source.AtLilyPond'
+'scopeName': 'source.lilypond'


### PR DESCRIPTION
In TextMate terminology, a grammar's `scopeName` is equivalent to a globally-unique identifier. There's no reason this should be named anything other than `source.lilypond`, which falls in line with every other LilyPond grammar.