### PR TITLE
Declare `language-lisp` as a package dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ AtLilyPond
 
 LilyPond syntax highlighting in Atom.
 
-**[INSTALLATION NOTE: AtLilyPond depends on the `language-lisp` package. Please ensure it is installed. If/when Atom provides a mechanism for declaring dependencies on other packages, this extra step will be no longer necessary.]**
-
 AtLilyPond is an [Atom](http://atom.io) port of my [SubLilyPond](https://www.github.com/yrammos/SubLilyPond) package for Sublime Text (also available for TextMate [here](https://www.github.com/yrammos/tmLilyPond)). For screenshots, release history, and other pertinent information, please visit the Github page of the [parent project](https://www.github.com/yrammos/SubLilyPond)
 
 For best results, you may need to try out different color schemes until you find one that adequately differentiates the various elements of your LilyPond code. As with any syntax highlighter, the potential of AtLilyPond can be fully realized only in the presence of an equally fine-grained color scheme. None of the built-in Atom schemes is particularly successful in this respect. Among other packages, I recommend `Base16 Light` and `Monokai` (but not `Atom Monokai`).

--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   "license": "CC BY-NC 3.0",
   "engines": {
     "atom": ">0.50.0"
-  }
+  },
+  "package-deps": [
+    "language-lisp"
+  ]
 }


### PR DESCRIPTION
While preparing [`yrammos/AtLilyPond#7`](https://github.com/yrammos/AtLilyPond/pull/7), I noticed this in the package readme:

> **[INSTALLATION NOTE: AtLilyPond depends on the `language-lisp` package. Please ensure it is installed. If/when Atom provides a mechanism for declaring dependencies on other packages, this extra step will be no longer necessary.]**

Atom does indeed feature the mechanism you described, although I'm not sure where/if it's documented in the flight manual. To give you a reference, the [`linter`](https://atom.io/packages/linter) package [uses it to ensure](https://github.com/steelbrain/linter/blob/410ece382f49778ff586964f525cfb73947d2388/package.json#L55-L57) every user has the [`linter-ui-default`](https://atom.io/packages/linter-ui-default) package installed in Atom first:

~~~json
  "package-deps": [
    "linter-ui-default"
  ],
~~~

This, along with the `scopeName` change you merged in earlier, should give you just enough to warrant cutting a new patch release (which will also be required for my `scopeName` change to have any effect...)